### PR TITLE
Fix Dokka configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,6 @@ test {
 }
 
 def dokkaConfiguration = {
-	processConfigurations = ['compile', 'compileOnly']
-
 	externalDocumentationLink {
 		url = new URL("https://hub.spigotmc.org/javadocs/bukkit/")
 	}


### PR DESCRIPTION
Remove the deprecated `processConfigurations` setting.

This fixes the Dokka build issues.