### PR TITLE
Fix deprecated classifier properties in jar tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,12 +87,12 @@ task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
 }
 
 task sourcesJar(type: Jar) {
-	classifier = 'sources'
+	archiveClassifier = 'sources'
 	from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
-	classifier = 'javadoc'
+	archiveClassifier = 'javadoc'
 	from javadoc.destinationDir
 }
 


### PR DESCRIPTION
`classifier` was deprecated in favour of `archiveClassifier`.